### PR TITLE
Enforce code conventions

### DIFF
--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd "$DIR/.."
+
+log() {
+  echo "$(basename ${BASH_SOURCE[0]}): $@"
+}
+
+install_hooks() {
+  git config core.hooksPath \
+    || git config core.hooksPath ./dev/hooks
+}
+
+log 're/configuring hooks...'
+install_hooks

--- a/dev/hooks/pre-commit
+++ b/dev/hooks/pre-commit
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Copyright 2012 The Go Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# git gofmt pre-commit hook
+#
+# To use, store as .git/hooks/pre-commit inside your repository and make sure
+# it has execute permissions.
+#
+# This script does not handle file names that contain spaces.
+
+gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
+[ -z "$gofiles" ] && exit 0
+
+unformatted=$(gofmt -l $gofiles)
+if [ ! -z "$unformatted" ]; then
+    # Some files are not gofmt'd. Print message and fail.
+
+    echo >&2 "Go files must be formatted with gofmt. Please run:"
+    for fn in $unformatted; do
+	echo >&2 "  gofmt -w $PWD/$fn"
+    done
+    exit 1
+fi
+
+if ! go vet; then
+    exit 1
+fi
+
+exit 0

--- a/main.go
+++ b/main.go
@@ -82,23 +82,23 @@ func getDailyUsage(acct, access string) {
 	// All users of cookiejar should import "golang.org/x/net/publicsuffix"
 	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 	if err != nil {
-        log.Fatal(err)
+		log.Fatal(err)
 	}
 
 	client := &http.Client{
-        Jar: jar,
+		Jar: jar,
 	}
 
 	url := "https://old.bwsc.org/ACCOUNTS/security_main.asp?AcctNum=%s&MtrNum=%s"
 	url = fmt.Sprintf(url, acct, access)
 	if _, err = client.Get(url); err != nil {
-        log.Fatal(err)
+		log.Fatal(err)
 	}
 
 	var resp *http.Response
 	daily_url := "https://old.bwsc.org/ACCOUNTS/readings_daily_30.asp"
 	if resp, err = client.Get(daily_url); err != nil {
-        log.Fatal(err)
+		log.Fatal(err)
 	}
 	// daily_html, err := ioutil.ReadAll(resp.Body)
 	// if err != nil {
@@ -107,7 +107,6 @@ func getDailyUsage(acct, access string) {
 	findTable(resp.Body)
 	resp.Body.Close()
 }
-
 
 func main() {
 	debugPtr := flag.Bool("debug", false, "Enable debugging")
@@ -136,10 +135,8 @@ func main() {
 	fmt.Println("accountNum:", accountNum)
 	fmt.Println("accessNum:", accessNum)
 
-
 	// Now retrieve data from bwsc.org
 	getDailyUsage(accountNum, accessNum)
-
 
 	return
 

--- a/main.go
+++ b/main.go
@@ -138,12 +138,12 @@ func main() {
 	// Now retrieve data from bwsc.org
 	getDailyUsage(accountNum, accessNum)
 
-	return
-
-	htmlReader, err := os.Open("bwsc-monthly.html")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer htmlReader.Close()
-	findTable(htmlReader)
+	// Read Monthly usage
+	//
+	// htmlReader, err := os.Open("bwsc-monthly.html")
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+	// defer htmlReader.Close()
+	// findTable(htmlReader)
 }


### PR DESCRIPTION
Add a git pre-commit hook to enforce go coding standards. Clean up the code with `go fmt`. 